### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/memu/src/bytes_impl.rs
+++ b/memu/src/bytes_impl.rs
@@ -247,7 +247,7 @@ macro_rules! data_impl {
             /// Returns a string containing`self.as_u64()` and `Self::UNIT`.
             #[cfg(feature = "units")]
             pub fn as_string_with_unit(&self) -> String {
-                format!("{:.}{}", self.as_f64(), Self::UNIT)
+                format!("{}{}", self.as_f64(), Self::UNIT)
             }
 
             /// Returns a string containing `self.as_f64()` with the given precision and `Self::UNIT`.


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.